### PR TITLE
Fix LDAP authentication.

### DIFF
--- a/Connection.php
+++ b/Connection.php
@@ -248,14 +248,15 @@ class Connection extends Component
         if($entry) {
             $this->userDn = $this->getDn($entry);        
         } else {
-            $this->userDn = null;
+            // User not found.
+            return false;
         }
 
         // Connect to the LDAP server.
         $this->connect($this->dc, $this->port);
 
-        // Authenticate user
-        return ldap_bind($this->resource, $this->userDn, $password);
+        // Try to authenticate user, but ignore any PHP warnings.
+        return @ldap_bind($this->resource, $this->userDn, $password);
     }
     
     /**


### PR DESCRIPTION
This change does the following:
1. makes the authentication fail if a user is not found instead of attempting to authenticate anonymously.
2. avoids logging an error and Yii2 error handler taking over when the user is found, but the password is incorrect.